### PR TITLE
Flashlight: add on/off (start off)

### DIFF
--- a/wasp/apps/flashlight.py
+++ b/wasp/apps/flashlight.py
@@ -31,6 +31,7 @@ class TorchApp(object):
 
     def background(self):
         """De-activate the application (without losing state)."""
+        self.__activated = False
         wasp.system.brightness = self._brightness
 
     def tick(self, ticks):

--- a/wasp/apps/flashlight.py
+++ b/wasp/apps/flashlight.py
@@ -19,13 +19,15 @@ class TorchApp(object):
     NAME = 'Torch'
     ICON = icons.torch
 
+    def __init__(self):
+        self.__activated = False
+
     def foreground(self):
         """Activate the application."""
+        self._brightness = wasp.system.brightness
         self.draw()
         wasp.system.request_tick(1000)
-
-        self._brightness = wasp.system.brightness
-        wasp.system.brightness = 3
+        wasp.system.request_event(wasp.EventMask.TOUCH | wasp.EventMask.BUTTON)
 
     def background(self):
         """De-activate the application (without losing state)."""
@@ -34,6 +36,38 @@ class TorchApp(object):
     def tick(self, ticks):
         wasp.system.keep_awake()
 
+    def touch(self, event):
+        self.__activated = not self.__activated
+        self.draw()
+
+    def press(self, button, state):
+        if not state:
+            return
+
+        self.__activated = not self.__activated
+        self.draw()
+
     def draw(self):
         """Redraw the display from scratch."""
-        wasp.watch.drawable.fill(0xffff)
+        white = 0xffff
+        draw = wasp.watch.drawable
+
+        if self.__activated:
+            draw.fill(white)
+            wasp.system.brightness = 3
+
+        else:
+            draw.fill()
+            wasp.system.brightness = self._brightness
+
+            x = 108
+            mid = wasp.system.theme('mid')
+
+            draw.fill(mid, x, 107, 24, 9)
+            for i in range(1, 8):
+                draw.line(x+i, 115+i, x+23-i, 115+i, color=mid)
+            draw.fill(mid, x+8, 123, 8, 15)
+
+            draw.line(x-3, 94, x+5, 102, 2, white)
+            draw.line(x+17, 102, x+25, 94, 2, white)
+            draw.line(x+11, 89, x+11, 100, 2, white)

--- a/wasp/apps/flashlight.py
+++ b/wasp/apps/flashlight.py
@@ -55,20 +55,23 @@ class TorchApp(object):
 
         if self.__activated:
             draw.fill(white)
+            self.draw_torch(0, 0)
             wasp.system.brightness = 3
 
         else:
             draw.fill()
+            self.draw_torch(wasp.system.theme('mid'), white)
             wasp.system.brightness = self._brightness
 
-            x = 108
-            mid = wasp.system.theme('mid')
+    def draw_torch(self, torch, light):
+        draw = wasp.watch.drawable
+        x = 108
 
-            draw.fill(mid, x, 107, 24, 9)
-            for i in range(1, 8):
-                draw.line(x+i, 115+i, x+23-i, 115+i, color=mid)
-            draw.fill(mid, x+8, 123, 8, 15)
+        draw.fill(torch, x, 107, 24, 9)
+        for i in range(1, 8):
+            draw.line(x+i, 115+i, x+23-i, 115+i, color=torch)
+        draw.fill(torch, x+8, 123, 8, 15)
 
-            draw.line(x-3, 94, x+5, 102, 2, white)
-            draw.line(x+17, 102, x+25, 94, 2, white)
-            draw.line(x+11, 89, x+11, 100, 2, white)
+        draw.line(x-3, 94, x+5, 102, 2, light)
+        draw.line(x+17, 102, x+25, 94, 2, light)
+        draw.line(x+11, 89, x+11, 100, 2, light)


### PR DESCRIPTION
Start flashlight app as "off", with a small icon, and toggle between this and actual flashlight on tap/button.
I use flashlight app in quick ring and this prevent accidental flash. 

![image](https://user-images.githubusercontent.com/6101998/134077806-7bce05ef-b556-4957-8d55-a8e35175b4b8.png)
![image](https://user-images.githubusercontent.com/6101998/134822487-0e89728e-3b27-41f5-b16e-03239bc630f5.png)

"off" screen with my theme:
![image](https://user-images.githubusercontent.com/6101998/134077753-f50f2304-7da1-4528-8d41-bcadc65a88ee.png)
