### PR TITLE
[alarms] Skip touch events on checkboxes of undefined alarms

### DIFF
--- a/wasp/apps/alarm.py
+++ b/wasp/apps/alarm.py
@@ -175,7 +175,7 @@ class AlarmApp:
                 self._remove_alarm(self.page)
         elif self.page == _HOME_PAGE:
             for index, checkbox in enumerate(self.alarm_checks):
-                if checkbox.touch(event):
+                if index < self.num_alarms and checkbox.touch(event):
                     if checkbox.state:
                         self.alarms[index][_ENABLED_IDX] |= _IS_ACTIVE
                     else:


### PR DESCRIPTION
Currently, we can tap where an alarm checkbox would be if a 2nd, 3rd or 4th alarm was created, while it's still not created, and that would change its status (leading to strange UI).

Before:
![image](https://user-images.githubusercontent.com/6101998/137553683-d95052a6-18e6-4251-b069-1646b9aae1ab.png)
