### PR TITLE
new: disable ppg light by default on startup

### DIFF
--- a/wasp/boards/k9/watch.py.in
+++ b/wasp/boards/k9/watch.py.in
@@ -101,6 +101,7 @@ try:
     accel = BMA421(i2c)
     boot_msg("Init HRS3300")
     hrs = HRS3300(i2c)
+    hrs.disable()
     boot_msg("Init touch")
     touch = TouchButton(Pin('TP_INT', Pin.IN),
                         Pin('TP_RST', Pin.OUT, value=0), _callback)

--- a/wasp/boards/p8/watch.py.in
+++ b/wasp/boards/p8/watch.py.in
@@ -90,6 +90,7 @@ try:
     i2c = I2C(1, scl='I2C_SCL', sda='I2C_SDA')
     accel = BMA421(i2c)
     hrs = HRS3300(i2c)
+    hrs.disable()
     touch = CST816S(i2c,
                     Pin('TP_INT', Pin.IN), Pin('TP_RST', Pin.OUT, value=0),
                     _callback)

--- a/wasp/boards/pinetime/watch.py.in
+++ b/wasp/boards/pinetime/watch.py.in
@@ -92,6 +92,7 @@ try:
     i2c = I2C(1, scl='I2C_SCL', sda='I2C_SDA')
     accel = BMA421(i2c)
     hrs = HRS3300(i2c)
+    hrs.disable()
     touch = CST816S(i2c,
                     Pin('TP_INT', Pin.IN), Pin('TP_RST', Pin.OUT, value=0),
                     _callback)


### PR DESCRIPTION
Fixes #307 : rebooting the watch while the HRS light is on will not turn it off.


Signed-off-by: thiswillbeyourgithub <github@32mail.33mail.com>
