### PR TITLE
add a test on string width

### DIFF
--- a/wasp/draw565.py
+++ b/wasp/draw565.py
@@ -310,8 +310,18 @@ class Draw565(object):
         font = self._font
         bg = self._bgfg >> 16
 
+        (w, h) = _bounding_box(s, font)
         if width:
+            wmax = min(width, 240 - x)
+            width = wmax
+        else:
+            wmax = 240 - x
+        while w > wmax:
+            # We need to strip the string
+            s = s[:-1]
             (w, h) = _bounding_box(s, font)
+
+        if width:
             if right:
                 leftpad = width - w
                 rightpad = 0


### PR DESCRIPTION
This pull request adds a verification on the length of a string before drawing, If the string is too long, it is trimmed.
I made some tests, with long texts and different widths, it seems to work well.

I understand if the mentality should be that programmers verify that their text fits well. Anyway I will keep it for my own fork, it makes it easier to change e.g. the font without breaking everything (if the new font is larger, text will be trimmed, instead of having an app not executing)