### PR TITLE
Doc update: how to autoload apps in flash

### DIFF
--- a/docs/appguide.rst
+++ b/docs/appguide.rst
@@ -417,6 +417,43 @@ section to add an import and register for you application from ``main.py``
             --exec wasp/drivers/cst816s.py\
             --eval "watch.touch = CST816S(watch.i2c)"`
 
+Auto loading applications in flash
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If there is not enough room on your device to freeze your application
+into the wasp-os binary you can still have it automatically added to
+the software list by uploading it to the apps directory of your device.
+The application will still have the RAM constraints of an app in flash.
+
+To automatically have your uploaded application added to the software:
+
+.. code-block:: sh
+
+    sh$ ./tools/wasptool --binary --upload myapp.mpy --as apps/myapp.mpy
+    Uploading apps/myapp.mpy:
+    [##################################################] 100%
+
+To delete a file from the device:
+
+.. code-block:: sh
+
+    sh$ ./tools/wasptool --console
+    >>>import os
+    >>>os.remove("apps/myapp.mpy")
+    >>>del os
+
+Application naming conventions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You app will have two names. A short name that will be displayed on the home
+screen and a long name to be displayed in the software list. Your files must be
+named according to the following rules:
+
+1) The class must be named the long name of the python file plus "App" (ie: "eggtimer.py" and "class EggTimerApp")
+2) Within your class the variable "NAME" must be set to the short name (ie: NAME= 'Timer' )
+3) Your app's documentation screenshot must be stored as the short name plus "App" (ie: res/TimerApp.png)
+4) The png used to generate your icon should be stored as the long name plus icon (ie: res/egg_timer_icon.png)
+
 Application entry points
 ------------------------
 


### PR DESCRIPTION
I'm not sure if this is even good practice. But I learned I could do this by reading the software.py file. I tried to get it to work using the upload command of the wasp tool but couldn't get it to work. But by using the push command I am easily able to store a .mpy so that its automatically added to the software list. 

I personally found this useful but it obviously still has the RAM constraints of a flash based program. I didn't think the docs made it clear this was possible. So I offer this update. If this is encouraging bad practice I'm interested in that as well.

Signed-off-by: Adam Blair adampblair@protonmail.com