### PR TITLE
Add nix development shell

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -77,6 +77,35 @@ All ``make`` commands should be usable from this shell,
 including ``make sim`` and ``make check``. Some commands that interact with
 bluetooth such as ``wasptool`` may not work, for now.
 
+Install prerequisites via Nix
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+    This setup method does not use the GCC version wasp-os is tested with,
+    but the gcc-arm-embedded package available from nixpkgs.
+    Though this usually works fine, if you encounter any problems please try the
+    manual installation above and report the issue in the issue tracker.
+
+To build wasp-os with `Nix <https://nixos.org/nix>`_, ensure it is installed
+then open a terminal and run the following command in the wasp-os repository:
+
+.. code-block:: sh
+
+    nix-shell tools/nix/shell.nix
+
+Or if you are using the experimental flake commands:
+
+.. code-block:: sh
+
+    nix develop ./tools/nix
+
+You will be dropped in a shell where all required dependencies are available.
+All ``make`` commands should be usable from this shell.
+
+Build
+~~~~~
+
 We can compile the modules required with the following commands:
 
 .. code-block:: sh

--- a/tools/nix/flake.nix
+++ b/tools/nix/flake.nix
@@ -1,0 +1,20 @@
+# NOTE: The officially tested toolchain is the one mentioned at
+# https://wasp-os.readthedocs.io/en/latest/install.html#install-prerequisites
+# So let's not add a flake.lock unless we test (and maintain) this thoroughly too.
+{
+  description = "A MicroPython based development environment for smart watches";
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSupportedSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in {
+      devShells = forAllSupportedSystems (system: {
+        default = import ./shell.nix { pkgs = nixpkgs.legacyPackages."${system}"; };
+      });
+    };
+}

--- a/tools/nix/shell.nix
+++ b/tools/nix/shell.nix
@@ -1,0 +1,36 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  # wasptool and ota-dfu only work on linux, and their dependencies prevent the
+  # shell to evaluate on darwin
+  ifLinux = pkgs.lib.optionals pkgs.stdenv.isLinux;
+
+in pkgs.mkShell {
+  nativeBuildInputs = [
+    (pkgs.python3.withPackages (pp: with pp; [
+      cbor
+      click
+      cryptography
+      dbus-python
+      numpy
+      pexpect
+      pillow
+      pygobject3
+      pysdl2
+      pyserial
+      tomli
+
+      pytest
+
+      # Docs
+      recommonmark
+      sphinx
+    ] ++ ifLinux [
+      bluepy
+    ]))
+    pkgs.gcc-arm-embedded
+    pkgs.graphviz
+  ] ++ ifLinux [
+    pkgs.bluez
+  ];
+}


### PR DESCRIPTION
Another way to get the toolchain on any linux and osx system. I've been using this since I started using wasp-os, and it's been working fine