### PR TITLE
Use `python -m` to run pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export PYTHONPATH := $(CURDIR)/tools/nrfutil:$(CURDIR)/tools/intelhex:$(PYTHONPATH)
 
 PYTHON ?= python3
-PYTEST ?= pytest-3
+PYTEST ?= $(PYTHON) -m pytest
 
 all : bootloader reloader micropython
 


### PR DESCRIPTION
Not every distro calls it `pytest-3`.
By using `$(PYTHON) -m` we ensure it's coherent with the python install

Closes #417 