### PR TITLE
Add option to disable oversized button hit area

### DIFF
--- a/wasp.toml
+++ b/wasp.toml
@@ -3,7 +3,7 @@
 
 [[app]]
 file = 'apps/stopwatch.py'
-quick_ring = true
+auto_load = true
 
 [[app]]
 file = 'apps/heart.py'
@@ -19,6 +19,7 @@ auto_load = true
 
 [[app]]
 file = 'apps/calculator.py'
+quick_ring = true
 
 [[app]]
 file = 'apps/disa_b_l_e.py'

--- a/wasp.toml
+++ b/wasp.toml
@@ -24,6 +24,14 @@ quick_ring = true
 [[app]]
 file = 'apps/disa_b_l_e.py'
 
+[[app]]
+file = 'apps/play2048.py'
+auto_load = true
+
+[[app]]
+file = 'apps/phone_finder.py'
+auto_load = true
+
 [[app]] # If only one watch face is included this app can be removed
 file = 'apps/faces.py'
 auto_load = true

--- a/wasp/widgets.py
+++ b/wasp/widgets.py
@@ -217,8 +217,9 @@ class ScrollIndicator:
 
 class Button():
     """A button with a text label."""
-    def __init__(self, x, y, w, h, label):
+    def __init__(self, x, y, w, h, label, oversized=True):
         self._im = (x, y, w, h, label)
+        self.oversized = oversized
 
     def draw(self):
         """Draw the button."""
@@ -246,12 +247,19 @@ class Button():
         x = event[1]
         y = event[2]
 
-        # Adopt a slightly oversized hit box
         im = self._im
-        x1 = im[0] - 10
-        x2 = x1 + im[2] + 20
-        y1 = im[1] - 10
-        y2 = y1 + im[3] + 20
+
+        if self.oversized:
+            # Adopt a slightly oversized hit box
+            x1 = im[0] - 10
+            x2 = x1 + im[2] + 20
+            y1 = im[1] - 10
+            y2 = y1 + im[3] + 20
+        else:
+            x1 = im[0]
+            x2 = x1 + im[2]
+            y1 = im[1]
+            y2 = y1 + im[3]
 
         if x >= x1 and x < x2 and y >= y1 and y < y2:
             return True


### PR DESCRIPTION
The oversized hit area can be problematic when there are many buttons close together, such as in the keyboard I'm developing. This adds an option to disable it.