### PR TITLE
wasp: navigate: sleep instead of vibe on swipe down

### DIFF
--- a/wasp/wasp.py
+++ b/wasp/wasp.py
@@ -315,7 +315,7 @@ class Manager():
                 else:
                     # Nothing to notify... we must handle that here
                     # otherwise the display will flicker.
-                    watch.vibrator.pulse()
+                    self.sleep()
 
         elif direction == EventType.HOME or direction == EventType.BACK:
             if self.app != app_list[0]:


### PR DESCRIPTION
I figure sleep is more useful than vibe. Plus, it helps minimize wear on the physical button.