### PR TITLE
wasp: Allow for clearing a tick request

### DIFF
--- a/wasp/wasp.py
+++ b/wasp/wasp.py
@@ -374,8 +374,12 @@ class Manager():
         Note: With the current simplistic timer implementation sub-second
         tick intervals are not possible.
         """
-        self.tick_period_ms = period_ms
-        self.tick_expiry = watch.rtc.get_uptime_ms() + period_ms
+        if period_ms:
+            self.tick_period_ms = period_ms
+            self.tick_expiry = watch.rtc.get_uptime_ms() + period_ms
+        else:
+            self.tick_period_ms = 0
+            self.tick_expiry = None
 
     def keep_awake(self):
         """Reset the keep awake timer."""


### PR DESCRIPTION
There currently appears to be no way to remove a tick request, and calling this func without args gives:

    self.tick_expiry = watch.rtc.get_uptime_ms() + period_ms
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'