### PR TITLE
Small change to fill() to exit early if there is nothing to do.

### DIFF
--- a/wasp/draw565.py
+++ b/wasp/draw565.py
@@ -150,9 +150,11 @@ class Draw565(object):
         if h is None:
             h = display.height - y
 
-        display.set_window(x, y, w, h)
-
         remaining = w * h
+        if remaining == 0:
+          return
+
+        display.set_window(x, y, w, h)
 
         # Populate the line buffer
         buf = display.linebuffer


### PR DESCRIPTION
This avoids running unnecessary code and avoids a bug in set_window().

For background see #251