### PR TITLE
Minimal change to string() to avoid the problem with fill()

### DIFF
--- a/wasp/draw565.py
+++ b/wasp/draw565.py
@@ -318,8 +318,9 @@ class Draw565(object):
             else:
                 leftpad = (width - w) // 2
                 rightpad = width - w - leftpad
-            self.fill(bg, x, y, leftpad, h)
-            x += leftpad
+            if leftpad != 0:
+                self.fill(bg, x, y, leftpad, h)
+                x += leftpad
 
         for ch in s:
             glyph = font.get_ch(ch)


### PR DESCRIPTION
Before the fix, `wasp.watch.draw.string('testwithareallylong', 0, 200, width=240)` calls `fill(0, y, 0, h)` which calls `set_window(0, y, 0, h)` which can't cope.

The fix is simply to detect that we are asking for a zero width fill and not do it.

The more general fix is to detect zero width or zero height calls in fill(), that is #460

Either of these fixes would close #251