### PR TITLE
docs: installation: --update normal operations

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -584,8 +584,14 @@ A default version of ``main.py`` is installed automatically when wasp-os initial
 formats the external flash as a file system.
 
 Most problems with normal mode operation occur either because ``main.py`` is
-missing, out-of-date or corrupt. These issues most commonly result in an
-entirely black screen when running the watch is running in normal mode.
+missing, out-of-date or corrupt, or because too many applications are being started
+by default, resulting in the system running out of RAM.
+
+Out of memory problems are best addressed by reducing the number of applications you
+have set to automatically load (auto_load in wasp.toml). If you are developing your
+own application, it is best that you load the minimal set of applications to have
+the maximum possible amount of available RAM and minimum fragmentation. For example,
+only autoloading the software app will get you the maximum amount of RAM.
 
 .. note::
 


### PR DESCRIPTION
Most new users of WASP-OS do not know the limitations and may attempt to autoload a number of applications that exceed the watch RAM capacity. So the user will have to reduce the number of applications chosen and re-install. This doc change has updates from DanielT (#465) and fgaz (#468) that I was not able to merge in those pr's.