### PR TITLE
tools/nix: fix wasptool

### DIFF
--- a/tools/nix/shell.nix
+++ b/tools/nix/shell.nix
@@ -6,6 +6,9 @@ let
   ifLinux = pkgs.lib.optionals pkgs.stdenv.isLinux;
 
 in pkgs.mkShell {
+  buildInputs = ifLinux [
+    pkgs.gobject-introspection
+  ];
   nativeBuildInputs = [
     (pkgs.python3.withPackages (pp: with pp; [
       cbor


### PR DESCRIPTION
Fixes "ImportError: cannot import name GLib, introspection typelib not found"