### PR TITLE
Python packages missing from requirements.txt

### DIFF
--- a/wasp/requirements.txt
+++ b/wasp/requirements.txt
@@ -1,6 +1,7 @@
 cbor
 click
 cryptography
+ecdsa
 meson-python
 numpy
 pexpect
@@ -10,4 +11,5 @@ pygobject
 pyserial
 pysdl2
 pytest
+recommonmark
 tomli


### PR DESCRIPTION
Added two requirements that are needed to build for both device and sim.
Python version 3.12 is also a requirement!

Signed-off-by: l33tlinuxh4x0r <l33tlinuxh4x0r@gmail.com>