### PR TITLE
Requirements txt updates

### DIFF
--- a/wasp/requirements.txt
+++ b/wasp/requirements.txt
@@ -1,6 +1,7 @@
 cbor
 click
 cryptography
+ecdsa
 meson-python
 numpy
 pexpect
@@ -10,4 +11,5 @@ pygobject
 pyserial
 pysdl2
 pytest
+recommonmark
 tomli


### PR DESCRIPTION
updated with two new requirements needed by waspos... ecdsa and recommonmark

ecdsa is required to sign the zip files and recommonmark or one of it's dependencies is required to run the sim